### PR TITLE
Implement Gmail Connector

### DIFF
--- a/examples/integration-tutorials/using-the-gmail-connector/README.md
+++ b/examples/integration-tutorials/using-the-gmail-connector/README.md
@@ -1,1 +1,107 @@
-# using-the-gmail-connector
+# Implement Gmail Connector Tutorial
+This sample demonstrates the use of Ballerina's GMail module to send an email to an email address. 
+
+
+## Module Overview 
+The Gmail connector allows you to send, read and delete emails through the Gmail REST API. It handles OAuth 2.0 authentication. It also provides the ability to read, trash, untrash, delete threads, get the Gmail profile, mailbox history etc. More details can be found in the [Gmail Module](https://github.com/wso2-ballerina/module-gmail/blob/master/Readme.md) repository
+
+### Pre-requisites
+- Setup [Ballerina 0.991.0](https://ballerina.io/downloads/)
+- Run the [Hospital-Service]() 
+- Obtain AuthTokens to run the sample 
+
+#### Obtaining Tokens to run the Sample
+1. Visit [Google API Console](https://console.developers.google.com), click **Create Project**, and follow the wizard to create a new project.
+2. Go to **Credentials -> OAuth consent screen**, enter a product name to be shown to users, and click **Save**.
+3. On the **Credentials** tab, click **Create credentials** and select **OAuth client ID**. 
+4. Select an application type, enter a name for the application, and specify a redirect URI (enter https://developers.google.com/oauthplayground if you want to use 
+[OAuth 2.0 playground](https://developers.google.com/oauthplayground) to receive the authorization code and obtain the 
+access token and refresh token). 
+5. Click **Create**. Your client ID and client secret appear. 
+6. In a separate browser window or tab, visit [OAuth 2.0 playground](https://developers.google.com/oauthplayground). Click on the `OAuth 2.0 configuration`
+ icon in the top right corner and click on `Use your own OAuth credentials` and provide your `OAuth Client ID` and `OAuth Client secret`.
+7. Select the required Gmail API scopes from the list of API's, and then click **Authorize APIs**.
+8. When you receive your authorization code, click **Exchange authorization code for tokens** to obtain the refresh token and access token.
+
+You can now enter the credentials in the HTTP client config. 
+```ballerina
+gmail:GmailConfiguration gmailConfig = {
+    clientConfig: {
+        auth: {
+            scheme: http:OAUTH2,
+            config: {
+                grantType: http:DIRECT_TOKEN,
+                config: {
+                    accessToken: testAccessToken,
+                    refreshConfig: {
+                        refreshUrl: gmail:REFRESH_URL,
+                        refreshToken: testRefreshToken,
+                        clientId: testClientId,
+                        clientSecret: testClientSecret
+                    }
+                }
+            }
+        }
+    }
+};
+
+gmail:Client gmailClient = new(gmailConfig);
+```
+
+## How it works
+In this example, we make use of the GMail connector to send a confirmation email regarding the payment status of a doctor's appointment.
+
+
+A JSON payload containing the necessary details is sent to the service. 
+
+```json
+{
+  "patient": {
+    "name": "John Doe",
+    "dob": "1940-03-19",
+    "ssn": "234-23-525",
+    "address": "California",
+    "phone": "8770586755",
+    "email": "johndoe@gmail.com"
+  },
+  "doctor": "thomas collins",
+  "hospital": "grand oak community hospital",
+  "appointment_date": "2025-04-02"
+}
+```
+
+ A request is made to the `Hospital-Service` which returns a JSON payload with the confirmation details such as the appointment number and fees. 
+ 
+ This payload can be used to generate a professional looking email, but for now we will just be sending it unaltered
+
+```json 
+{
+    "appointmentNumber": 1,
+    "doctor": {
+        "name": "thomas collins",
+        "hospital": "grand oak community hospital",
+        "category": "surgery",
+        "availability": "9.00 a.m - 11.00 a.m",
+        "fee": 7000
+    },
+    "patient": {
+        "name": "John Doe",
+        "dob": "1940-03-19",
+        "ssn": "234-23-525",
+        "address": "California",
+        "phone": "8770586755",
+        "email": "johndoe@gmail.com"
+    },
+    "fee": 7000,
+    "confirmed": false,
+    "appointmentDate": "2025-04-02"
+}
+```
+With the necessary `MessageRequest` details specified, the payload can be sent to its intended recipient and a reponse is sent back to the caller confirming the receipt of the email. 
+
+```json
+{
+    "Message": "The email has been successfully sent",
+    "Recipient": "someone@gmail.com"
+}
+```

--- a/examples/integration-tutorials/using-the-gmail-connector/gmail_connector.bal
+++ b/examples/integration-tutorials/using-the-gmail-connector/gmail_connector.bal
@@ -1,0 +1,125 @@
+// Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/io;
+import ballerina/http;
+import ballerina/log;
+import wso2/gmail;
+
+# Gmail client endpoint declaration with oAuth2 client configurations
+gmail:GmailConfiguration gmailConfig = {
+    clientConfig: {
+        auth: {
+            scheme: http:OAUTH2,
+            config: {
+                grantType: http:DIRECT_TOKEN,
+                config: {
+                    accessToken: "ya29.GlwgB6Nbn8FLTeNy4qJGDywJyheIKt0M7OUu5Q5yxrEA0033LMHM4BA-kzxbpmdjwkhaO6CJJ5_mdR55EjP-g-5Bk-wo2HdIiWCjiwDJfzNU-111X2yB_DJOagZMHQ",
+                    refreshConfig: {
+                        refreshUrl: gmail:REFRESH_URL,
+                        refreshToken: "1/sUpgjclqE_KwPnqGlVs6pvFHjL2_fefkI_OOXuxZolJNOUjpmQdr-uYuQoameOic",
+                        clientId: "924967501288-12je7sdbirp167m61gsrujbnni0c5u58.apps.googleusercontent.com",
+                        clientSecret: "iDPT9j2_gMiUGgxDyEv8bj7i&grant_type=refresh_token&refresh_token=1%2FsUpgjclqE_KwPnqGlVs6pvFHjL2_fefkI_OOXuxZolJNOUjpmQdr-uYuQoameOic&client_id=924967501288-12je7sdbirp167m61gsrujbnni0c5u58.apps.googleusercontent.com"
+                    }
+                }
+            }
+        }
+    }
+};
+
+//Gmail client that handles sending payloads to email address
+gmail:Client gmailClient = new(gmailConfig);
+//Listener endpoint that the service binds to 
+listener http:Listener endpoint = new(9091);
+
+//Change the service URL to base /surgery
+@http:ServiceConfig {
+    basePath: "/surgery"
+}
+service gmailConnector on new http:Listener(9091) {
+
+    //Decorate "reserve" resource path to accept POST requests
+    @http:ResourceConfig {
+        methods: ["POST"],
+        path: "/reserve"
+    }
+    resource function settleReservation(http:Caller caller, http:Request request) {
+        var payload = request.getJsonPayload();
+        http:Response response = new;
+
+        if (payload is json) {
+            http:Client clientEp = new("http://localhost:9090");
+
+            var backendResponse = clientEp->post("/grandoaks/categories/surgery/reserve", untaint payload);
+
+            if (backendResponse is http:Response) {
+                var jsonPayload = backendResponse.getJsonPayload();
+
+                if (jsonPayload is json) {
+                    response = sendToGmail(untaint jsonPayload);
+                } else {
+                    log:printError("Invalid Json payload recieved from backend");
+                }
+            } else {
+                log:printError("Error in sending request to backend. Invalid response", err = backendResponse);
+            }
+        } else {
+            response.statusCode = 500;
+            response.setPayload("Payload is not a valid JSON format");
+        }
+
+        var result = caller->respond(response);
+        if (result is error) {
+            log:printError("Error in responding", err = result);
+        }
+    }
+}
+
+// Sends the payload to Gmail
+function sendToGmail(json jsonPayload) returns http:Response {
+    string messageBody = jsonPayload.toString();
+    http:Response response = new;
+
+    string userId = "me";
+    gmail:MessageRequest messageRequest = {};
+    messageRequest.recipient = "aquib.zt@gmail.com";
+    messageRequest.sender = "aquib@wso2.com";
+    messageRequest.subject = "Gmail Connector test : Payment Status";
+    messageRequest.messageBody = messageBody;
+    messageRequest.contentType = gmail:TEXT_PLAIN;
+
+    // Send the message.
+    var sendMessageResponse = gmailClient->sendMessage(userId, messageRequest);
+
+    if (sendMessageResponse is (string, string)) {
+        // If successful, print the message ID and thread ID.
+        (string, string) (messageId, threadId) = sendMessageResponse;
+        io:println("Sent Message ID: " + messageId);
+        io:println("Sent Thread ID: " + threadId);
+
+        json payload = {
+            Message: "The email has been successfully sent",
+            Recipient: messageRequest.recipient
+        };
+        response.setJsonPayload(payload, contentType = "application/json");
+    } else {
+        // If unsuccessful, print the error returned.
+        io:println("Error: ", sendMessageResponse);
+        response.setPayload("Failed to send the Email");
+    }
+
+    return response;
+}


### PR DESCRIPTION
- Sample demonstrating the use of the Ballerina Gmail Module with the
Hospital-Service backend

## Approach
- Create a service under context /surgery/reserve which accepts JSON payloads to make reservations 
- Send the received payload to the Hospital-Service backend context. 
- Forward the response to `sendToGmail()` function which sends an email to the specified recipient
- On success, send response to the caller confirming the receipt of the email. Otherwise print an error

## Documentation
Ballerina's Gmail Module : https://github.com/wso2-ballerina/module-gmail/blob/master/Readme.md
Related E.I Usecase Doc : https://docs.wso2.com/display/EI650/Using+the+Gmail+Connector

### Related issue : https://github.com/wso2/ballerina-integrator/issues/11