### PR TITLE
Modify "/healthcare/payments" to return a JSON response

### DIFF
--- a/examples/guides/services/healthcare-service/service/healthcare_service.bal
+++ b/examples/guides/services/healthcare-service/service/healthcare_service.bal
@@ -171,8 +171,11 @@ service HealthcareService on httpListener {
                     if(payment is daos:Payment) {
                         payment["status"] = "Settled";
                         self.healthcareDao["payments"][<string>payment["paymentID"]] = payment;
-                        util:sendResponse(caller, "Settled payment successfully with payment ID: " 
-                                                                        + <string>payment["paymentID"]);
+                        json payload = {
+                            status: "success",
+                            paymentId: <string>payment["paymentID"]
+                        };
+                        util:sendResponse(caller, payload);
                     } else {
                         log:printError("User error Invalid payload recieved, payload: ", err = payment);
                         util:sendResponse(caller, "Invalid payload recieved, " + payment.reason(), 


### PR DESCRIPTION
## Purpose
Modified to return following JSON response rather than returning a text response.
```
{
	"status": "success",
	"paymentId": "4685e08a-5495-4054-858a-2ae21b7ae8d7"
}
```
Fixes; https://github.com/wso2/ballerina-integrator/issues/79