### PR TITLE
Add condition not to settle payments for invalid appointment IDs

### DIFF
--- a/examples/guides/services/healthcare-service/service/healthcare_service.bal
+++ b/examples/guides/services/healthcare-service/service/healthcare_service.bal
@@ -163,7 +163,8 @@ service HealthcareService on httpListener {
                                                 daos:PaymentSettlement.convert(paymentSettlementDetails);
 
             if(paymentSettlement is daos:PaymentSettlement) {
-                if(<int>paymentSettlement["appointmentNumber"] >= 0) {
+                if(util:containsAppointmentId(self.appointments, 
+                            string.convert(<int>paymentSettlement["appointmentNumber"]))) {
                     // Create new payment entry for the appointment.
                     daos:Payment|error payment = 
                             util:createNewPaymentEntry(paymentSettlement, untaint self.healthcareDao);


### PR DESCRIPTION
## Purpose
> In healthcare-service.bal, payments can be settled mentioning invalid appointment numbers through post /healthcare/payments.

## Goals
> Show error message to the user for invalid appointment numbers.

## Approach
> Adding a condition to check given appointment number is exists in the appointments map.

Resolves; https://github.com/wso2/ballerina-integrator/issues/73