### PR TITLE
Fix code insertion alignment issue and add images to mkdocs-content

### DIFF
--- a/www/src/main/java/org/wso2/integration/ballerina/constants/Constants.java
+++ b/www/src/main/java/org/wso2/integration/ballerina/constants/Constants.java
@@ -29,6 +29,7 @@ public final class Constants {
     public static final String DOCS_DIR = ".." + File.separator + "docs";
     public static final String TEMP_DIR = "tempDirectory";
     public static final String MKDOCS_CONTENT = "target" + File.separator + "mkdocs-content";
+    public static final String ASSETS_IMG_DIR = DOCS_DIR + File.separator + "assets" + File.separator + "img";
 
     // Files
     public static final String README_MD = "README.md";

--- a/www/src/main/java/org/wso2/integration/ballerina/utils/Utils.java
+++ b/www/src/main/java/org/wso2/integration/ballerina/utils/Utils.java
@@ -255,4 +255,24 @@ public class Utils {
         File parent = tomlFile.getParentFile();
         return parent.getPath() + File.separator + parent.getName() + ".zip";
     }
+
+    /**
+     * Remove leading whitespaces of a given string.
+     *
+     * @param param string want to remove leading whitespaces
+     * @return string without leading whitespaces
+     */
+    public static String removeLeadingSpaces(String param) {
+        return param.replaceAll("^\\s+", EMPTY_STRING);
+    }
+
+    /**
+     * Get leading whitespaces of a given string.
+     *
+     * @param param string want to get leading whitespaces
+     * @return leading whitespaces of the string
+     */
+    public static String getLeadingWhitespaces(String param) {
+        return param.replace(removeLeadingSpaces(param), EMPTY_STRING);
+    }
 }


### PR DESCRIPTION
## Purpose
- Fix code insertion alignment issue by when the user is adding `INCLUDE_CODE_TAG` with leading whitespaces, those leading whitespaces added to every line of the insertion code.

   repo/README.md
   ```
   6. Open the project with VSCode. The integration implementation going to write in the 
   `src/guide/main.bal` file.

          **main.bal**
          <!-- INCLUDE_CODE: src/guide/main.bal -->
   ```

   mkdocs-content/README.md
   ```
   6. Open the project with VSCode. The integration implementation going to write in the `src/guide/main.bal` file.

          **main.bal**
          ```ballerina
          import ballerina/config;
          import ballerina/io;
          import ballerina/log;
   ```

- Add images inside `docs/assets/img` to `mkdocs-content`

Fixes https://github.com/wso2/ballerina-integrator/issues/335

