### PR TITLE
Fix code insertion alignment issue and add images to mkdocs-content

### DIFF
--- a/docs/doc-generator/src/main/java/org/wso2/integration/ballerina/DocsGenerator.java
+++ b/docs/doc-generator/src/main/java/org/wso2/integration/ballerina/DocsGenerator.java
@@ -39,6 +39,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
+import static org.wso2.integration.ballerina.constants.Constants.ASSETS_IMG_DIR;
 import static org.wso2.integration.ballerina.constants.Constants.BALLERINA_TOML;
 import static org.wso2.integration.ballerina.constants.Constants.CLOSE_CURLY_BRACKET;
 import static org.wso2.integration.ballerina.constants.Constants.CODE_SEGMENT_BEGIN;
@@ -54,6 +55,7 @@ import static org.wso2.integration.ballerina.constants.Constants.INCLUDE_CODE_SE
 import static org.wso2.integration.ballerina.constants.Constants.INCLUDE_CODE_TAG;
 import static org.wso2.integration.ballerina.constants.Constants.MARKDOWN_FILE_EXT;
 import static org.wso2.integration.ballerina.constants.Constants.MKDOCS_CONTENT;
+import static org.wso2.integration.ballerina.constants.Constants.NEW_LINE;
 import static org.wso2.integration.ballerina.constants.Constants.OPEN_CURLY_BRACKET;
 import static org.wso2.integration.ballerina.constants.Constants.README_MD;
 import static org.wso2.integration.ballerina.constants.Constants.TEMP_DIR;
@@ -66,6 +68,7 @@ import static org.wso2.integration.ballerina.utils.Utils.deleteFile;
 import static org.wso2.integration.ballerina.utils.Utils.getCodeFile;
 import static org.wso2.integration.ballerina.utils.Utils.getCommitHash;
 import static org.wso2.integration.ballerina.utils.Utils.getCurrentDirectoryName;
+import static org.wso2.integration.ballerina.utils.Utils.getLeadingWhitespaces;
 import static org.wso2.integration.ballerina.utils.Utils.getMarkdownCodeBlockWithCodeType;
 import static org.wso2.integration.ballerina.utils.Utils.getPostFrontMatter;
 import static org.wso2.integration.ballerina.utils.Utils.getZipFileName;
@@ -200,7 +203,7 @@ public class DocsGenerator {
         String fullPathOfIncludeCodeFile = readMeParentPath + getIncludeFilePathFromIncludeCodeLine(line);
         File includeCodeFile = new File(fullPathOfIncludeCodeFile);
         String code = removeLicenceHeader(getCodeFile(includeCodeFile, readMeParentPath)).trim();
-        return getMarkdownCodeBlockWithCodeType(fullPathOfIncludeCodeFile, code);
+        return handleCodeAlignment(line, getMarkdownCodeBlockWithCodeType(fullPathOfIncludeCodeFile, code));
     }
 
     /**
@@ -226,7 +229,7 @@ public class DocsGenerator {
         String codeFileContent = removeLicenceHeader(getCodeFile(includeCodeFile, readMeParentPath));
 
         String code = getCodeSegment(codeFileContent, segment).trim();
-        return getMarkdownCodeBlockWithCodeType(fullPathOfIncludeCodeFile, code);
+        return handleCodeAlignment(line, getMarkdownCodeBlockWithCodeType(fullPathOfIncludeCodeFile, code));
     }
 
     /**
@@ -242,6 +245,20 @@ public class DocsGenerator {
         } catch (ArrayIndexOutOfBoundsException e) {
             throw new ServiceException("Invalid code segment including. segmentName: " + segmentName);
         }
+    }
+
+    /**
+     * Handle alignment of the code inclusion. Leading whitespaces of the INCLUDE_CODE_TAG line should be added
+     * to the beginning of each code line.
+     * <WHITESPACES>INCLUDE_CODE_TAG => <WHITESPACES>{code}
+     *
+     * @param line INCLUDE_CODE_TAG line
+     * @param code code content as a string
+     * @return aligned code
+     */
+    private static String handleCodeAlignment(String line, String code) {
+        String leadingSpaces = getLeadingWhitespaces(line);
+        return leadingSpaces + code.replace(NEW_LINE, NEW_LINE + leadingSpaces);
     }
 
     /**
@@ -288,8 +305,9 @@ public class DocsGenerator {
         boolean mdFile = FilenameUtils.getExtension(file.getName()).equals(MARKDOWN_FILE_EXT);
         boolean moduleMdFile = file.getName().equals("Module.md");
         boolean zipFile = FilenameUtils.getExtension(file.getName()).equals("zip");
+        boolean imgFile = new File(ASSETS_IMG_DIR, file.getName()).exists();
 
-        return !((mdFile && !moduleMdFile) || zipFile);
+        return !((mdFile && !moduleMdFile) || zipFile || imgFile);
     }
 
     /**

--- a/docs/doc-generator/src/main/java/org/wso2/integration/ballerina/constants/Constants.java
+++ b/docs/doc-generator/src/main/java/org/wso2/integration/ballerina/constants/Constants.java
@@ -29,6 +29,7 @@ public final class Constants {
     public static final String DOCS_DIR = ".." + File.separator + ".." + File.separator + "docs";
     public static final String TEMP_DIR = "target" + File.separator + "tempDirectory";
     public static final String MKDOCS_CONTENT = "target" + File.separator + "mkdocs-content";
+    public static final String ASSETS_IMG_DIR = DOCS_DIR + File.separator + "assets" + File.separator + "img";
 
     // Files
     public static final String README_MD = "README.md";

--- a/docs/doc-generator/src/main/java/org/wso2/integration/ballerina/utils/Utils.java
+++ b/docs/doc-generator/src/main/java/org/wso2/integration/ballerina/utils/Utils.java
@@ -251,6 +251,32 @@ public class Utils {
         }
     }
 
+    /**
+     * Remove leading whitespaces of a given string.
+     *
+     * @param param string want to remove leading whitespaces
+     * @return string without leading whitespaces
+     */
+    private static String removeLeadingSpaces(String param) {
+        return param.replaceAll("^\\s+", EMPTY_STRING);
+    }
+
+    /**
+     * Get leading whitespaces of a given string.
+     *
+     * @param param string want to get leading whitespaces
+     * @return leading whitespaces of the string
+     */
+    public static String getLeadingWhitespaces(String param) {
+        return param.replace(removeLeadingSpaces(param), EMPTY_STRING);
+    }
+
+    /**
+     * Get zip file name using the toml file path.
+     *
+     * @param tomlFile toml file
+     * @return zip file name
+     */
     public static String getZipFileName(File tomlFile) {
         File parent = tomlFile.getParentFile();
         return parent.getPath() + File.separator + parent.getName() + ".zip";


### PR DESCRIPTION
## Purpose
- Fix code insertion alignment issue by when the user is adding `INCLUDE_CODE_TAG` with leading whitespaces, those leading whitespaces added to every line of the insertion code.

   repo/README.md
   ```
   6. Open the project with VSCode. The integration implementation going to write in the 
   `src/guide/main.bal` file.

          **main.bal**
          <!-- INCLUDE_CODE: src/guide/main.bal -->
   ```

   mkdocs-content/README.md
   ```
   6. Open the project with VSCode. The integration implementation going to write in the `src/guide/main.bal` file.

          **main.bal**
          ```ballerina
          import ballerina/config;
          import ballerina/io;
          import ballerina/log;
   ```

- Add images inside `docs/assets/img` to `mkdocs-content`

Fixes https://github.com/wso2/ballerina-integrator/issues/335