### PR TITLE
Add include markdown content functionality to docs-generator

### DIFF
--- a/docs/content/src/learn/tutorials/database-integrations/data-backed-service/README.md
+++ b/docs/content/src/learn/tutorials/database-integrations/data-backed-service/README.md
@@ -25,11 +25,7 @@ This service will deal with a MySQL database and expose the data operations as a
 
 ![alt text](resources/data-backed-service.svg)
 
-## Prerequisites
- 
-* Ballerina Integrator
-* A Text Editor or an IDE 
-> **Tip**: For a better development experience, install the Ballerina Integrator extension in [VS Code](https://code.visualstudio.com).
+<!-- INCLUDE_MD: ../../../../tutorial-prerequisites.md -->
 * [MySQL version 5.6 or later](https://www.mysql.com/downloads/)
 * [Official JDBC driver](https://dev.mysql.com/downloads/connector/j/) for MySQL   
 

--- a/docs/content/src/tutorial-prerequisites.md
+++ b/docs/content/src/tutorial-prerequisites.md
@@ -1,0 +1,5 @@
+## Prerequisites
+ 
+* Ballerina Integrator
+* A Text Editor or an IDE 
+> **Tip**: For a better development experience, install the Ballerina Integrator extension in [VS Code](https://code.visualstudio.com).

--- a/docs/doc-generator/README.md
+++ b/docs/doc-generator/README.md
@@ -121,7 +121,15 @@ function handleResponse(http:Response | error response) returns http:Response {
 }
 ```
 
-### 3. Include images
+### 3. Include markdown content
+
+Use below syntax to add markdown files. So when pre-processing `README.md` files this tag will be replaced with the 
+actual markdown file content given in `INCLUDE_MD` tag.
+```
+<!-- INCLUDE_MD: path/to/file/prerequisites.md -->
+```
+
+### 4. Include images
 
 If you want to add images and add image attachments to your `README.md` file add all the images to `docs/assets/img`
 and add the image attachment in the `README.md` file.

--- a/docs/doc-generator/src/main/java/org/wso2/integration/ballerina/DocsGenerator.java
+++ b/docs/doc-generator/src/main/java/org/wso2/integration/ballerina/DocsGenerator.java
@@ -54,6 +54,7 @@ import static org.wso2.integration.ballerina.constants.Constants.GIT_PROPERTIES_
 import static org.wso2.integration.ballerina.constants.Constants.HASH;
 import static org.wso2.integration.ballerina.constants.Constants.INCLUDE_CODE_SEGMENT_TAG;
 import static org.wso2.integration.ballerina.constants.Constants.INCLUDE_CODE_TAG;
+import static org.wso2.integration.ballerina.constants.Constants.INCLUDE_MD_TAG;
 import static org.wso2.integration.ballerina.constants.Constants.MARKDOWN_FILE_EXT;
 import static org.wso2.integration.ballerina.constants.Constants.MKDOCS_CONTENT;
 import static org.wso2.integration.ballerina.constants.Constants.NEW_LINE;
@@ -179,6 +180,8 @@ public class DocsGenerator {
                     readMeFileContent = readMeFileContent.replace(line, getPostFrontMatter(line, commitHash));
                 } else if (isImageAttachmentLine(line)) {
                     readMeFileContent = readMeFileContent.replace(line, getWebsiteImageAttachment(line));
+                } else if (line.contains(INCLUDE_MD_TAG)) {
+                    readMeFileContent = readMeFileContent.replace(line, getIncludeMarkdownFile(file.getParent(), line));
                 }
             }
             IOUtils.write(readMeFileContent, new FileOutputStream(file), String.valueOf(StandardCharsets.UTF_8));
@@ -210,7 +213,7 @@ public class DocsGenerator {
      * @return code content of the code file should be included
      */
     private static String getIncludeCodeFile(String readMeParentPath, String line) {
-        String fullPathOfIncludeCodeFile = readMeParentPath + getIncludeFilePathFromIncludeCodeLine(line);
+        String fullPathOfIncludeCodeFile = readMeParentPath + getIncludeFilePathFromIncludeCodeLine(line, INCLUDE_CODE_TAG);
         File includeCodeFile = new File(fullPathOfIncludeCodeFile);
         String code = removeLicenceHeader(getCodeFile(includeCodeFile, readMeParentPath), readMeParentPath).trim();
         return handleCodeAlignment(line, getMarkdownCodeBlockWithCodeType(fullPathOfIncludeCodeFile, code));
@@ -272,14 +275,14 @@ public class DocsGenerator {
     }
 
     /**
-     * get file path of the INCLUDE_CODE_TAG line.
+     * get file path of the INCLUDE_TAG line.
      *
-     * @param line line having INCLUDE_CODE_TAG
-     * @return file path of the code file should be included
+     * @param line line having INCLUDE_TAG
+     * @return file path of the file should be included
      */
-    private static String getIncludeFilePathFromIncludeCodeLine(String line) {
+    private static String getIncludeFilePathFromIncludeCodeLine(String line, String includeTag) {
         return "/" + line.replace(COMMENT_START, EMPTY_STRING).replace(COMMENT_END, EMPTY_STRING)
-                .replace(INCLUDE_CODE_TAG, EMPTY_STRING).trim();
+                .replace(includeTag, EMPTY_STRING).trim();
     }
 
     /**
@@ -464,5 +467,18 @@ public class DocsGenerator {
     private static String getWebsiteImageAttachment(String line) {
         String imageUrl = line.trim().split("]\\(")[1].replace(")", EMPTY_STRING);
         return line.replace(imageUrl, "../" + imageUrl);
+    }
+
+    /**
+     * Get markdown file content should be included in the README.md file.
+     *
+     * @param readMeParentPath parent path of the README.md file
+     * @param line             line having INCLUDE_MD_TAG
+     * @return content of the markdown file should be included
+     */
+    private static String getIncludeMarkdownFile(String readMeParentPath, String line) {
+        String fullPathOfIncludeMdFile = readMeParentPath + getIncludeFilePathFromIncludeCodeLine(line, INCLUDE_MD_TAG);
+        File includeMdFile = new File(fullPathOfIncludeMdFile);
+        return getCodeFile(includeMdFile, readMeParentPath).trim();
     }
 }

--- a/docs/doc-generator/src/main/java/org/wso2/integration/ballerina/constants/Constants.java
+++ b/docs/doc-generator/src/main/java/org/wso2/integration/ballerina/constants/Constants.java
@@ -28,7 +28,7 @@ public final class Constants {
     // Directory paths
     public static final String DOCS_DIR = ".." + File.separator + ".." + File.separator + "docs" + File.separator
             + "content" + File.separator + "src";
-    public static final String TARGET_DIR = "target";
+    private static final String TARGET_DIR = "target";
     public static final String TEMP_DIR = TARGET_DIR + File.separator + "tempDirectory";
     public static final String MKDOCS_CONTENT = TARGET_DIR + File.separator + "mkdocs-content";
     public static final String ASSETS_IMG_DIR = DOCS_DIR + File.separator + "assets" + File.separator + "img";
@@ -43,6 +43,7 @@ public final class Constants {
     // Special syntax
     public static final String INCLUDE_CODE_TAG = "INCLUDE_CODE:";
     public static final String INCLUDE_CODE_SEGMENT_TAG = "INCLUDE_CODE_SEGMENT:";
+    public static final String INCLUDE_MD_TAG = "INCLUDE_MD:";
     public static final String EMPTY_STRING = "";
     public static final String COMMENT_START = "<!--";
     public static final String COMMENT_END = "-->";


### PR DESCRIPTION
## Purpose
Add include markdown content functionality to docs-generator.
Include markdown content functionality is using below syntax to add markdown files. 
So when pre-processing `README.md` files,  `INCLUDE_MD` tag will be replaced with the 
actual markdown file content given in tag.
```
<!-- INCLUDE_MD: path/to/file/prerequisites.md -->
```