### PR TITLE
Fix dashboard issue after error is thrown and README.md improvements

### DIFF
--- a/vscode/extension/README.md
+++ b/vscode/extension/README.md
@@ -9,7 +9,7 @@ WSO2 Ballerina Integrator VS Code extension is a tool that is used alongside the
 
 ## Quick Start
 - **Step 1:** Install the WSO2 Ballerina Integrator extension for Visual Studio Code.
-- **Step 2:** Use the command `Ballerina Integrator: Dashboard` through the command palette to start creating projects and modules using multiple different templates provided.
+- **Step 2:** Use the command `Ballerina Integrator: Dashboard` through the command palette ([Command] + [Shift] + [P] on macOS and [Ctrl] + [Shift] + [P] on Windows/Linux) to start creating projects and modules using multiple different templates provided.
 
 ## Useful Commands
 Open the Command Palette ([Command] + [Shift] + [P] on macOS and [Ctrl] + [Shift] + [P] on Windows/Linux) and type in one of the following commands.

--- a/vscode/extension/src/createProject.ts
+++ b/vscode/extension/src/createProject.ts
@@ -64,7 +64,7 @@ export async function createTemplateProject(currentPanel: vscode.WebviewPanel, c
                         const newCommand = 'cd ' + projectUri.fsPath + ' && ballerina new ' + projectName;
                         // Execute the Ballerina new command to create a project.
                         await new Promise((resolve, reject) => {
-                            childProcess.exec(newCommand, newProjectCommand(reject, projectUri, resolve));
+                            childProcess.exec(newCommand, newProjectCommand(reject, projectUri, resolve, currentPanel));
                         });
                         let projectFolder = appendPath(projectUri.fsPath, projectName);
                         const addCommandWithoutTemplate = 'cd ' + projectFolder.fsPath + ' && ballerina add ' + moduleName;
@@ -129,7 +129,7 @@ export async function createTemplateProject(currentPanel: vscode.WebviewPanel, c
                                 if (folderPath != undefined) {
                                     const newCommand = 'cd ' + projectUri.fsPath + ' && ballerina new ' + projectName;
                                     await new Promise((resolve, reject) => {
-                                        childProcess.exec(newCommand, newProjectCommand(reject, projectUri, resolve));
+                                        childProcess.exec(newCommand, newProjectCommand(reject, projectUri, resolve, currentPanel));
                                     });
                                     uri = appendPath(projectUri.fsPath, projectName).fsPath;
                                 }
@@ -197,7 +197,7 @@ function appendPath (path: string, appendString: string): Uri {
 }
 
 // Handles the new project creation command result.
-function newProjectCommand(reject: (reason?: any) => void, projectUri: vscode.Uri, resolve: (value?: unknown) => void): any {
+function newProjectCommand(reject: (reason?: any) => void, projectUri: vscode.Uri, resolve: (value?: unknown) => void, currentPanel:vscode.WebviewPanel): any {
     return (err, stderr, stdout) => {
         const message = "Created new Ballerina project";
         if (err) {
@@ -211,6 +211,8 @@ function newProjectCommand(reject: (reason?: any) => void, projectUri: vscode.Ur
         }
         else {
             window.showErrorMessage(stdout + " " + stderr);
+            currentPanel.dispose();
+            vscode.commands.executeCommand("ballerina.integrator.activate");
             reject();
         }
     };


### PR DESCRIPTION
## Purpose
> Resolves #604 and #610 

## Goals
> - Update README.md with the shortcut to open the command palette
> - Fix issue where dashboard becomes irresponsive after an error is shown